### PR TITLE
feat: Display featured image thumbnails on home page

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,57 @@
+{{ define "main" }}
+  <article class="cf ph3 ph5-l pv3 pv4-l f4 tc-l center measure-wide lh-copy {{ $.Param "text_color" | default "mid-gray" }}">
+      {{ .Content }}
+    </article>
+    {{/* Define a section to pull recent posts from. For Hugo 0.20 this will def allt to the section with the most number of pages. */}}
+    {{ $mainSections := .Site.Params.mainSections | default (slice "post") }}
+
+    {{/* Check to see if the section is defined for ranging through it */}}
+    {{range ($mainSections)}}
+    {{/* Derive the section name  */}}
+    {{ $section_name := . }}
+    {{/* Create a variable with that section to use in multiple places. */}}
+    {{ $section := where $.Site.RegularPages "Section" "in" $section_name }}
+    {{ $section_count := len $section }}
+    {{ if ge $section_count 1 }}
+      <div class="pa3 pa4-ns w-100 w-70-ns center">
+        {{/* Use $section_name to get the section title. Use "with" to only show it if it exists */}}
+        {{ with $.Site.GetPage "section" $section_name }}
+            <h1 class="flex-none">
+              {{ $.Param "recent_copy" | default (i18n "recentTitle" .) }}
+            </h1>
+          {{ end }}
+
+        {{ $n_posts := $.Param "recent_posts_number" | default 3 }}
+
+        <section class="w-100 mw8">
+          {{/* Range through the first $n_posts items of the section */}}
+          {{ range (first $n_posts $section) }}
+            <div class="relative w-100 mb4">
+              {{ .Render "summary-with-image" }}
+            </div>
+          {{ end }}
+        </section>
+
+        {{ if ge $section_count (add $n_posts 1) }}
+        <section class="w-100">
+          <h1 class="f3">{{ i18n "more" }}</h1>
+          {{/* Now, range through the next four after the initial $n_posts items . Nest the requirements, "after" then "first" on the outside */}}
+          {{ range (first 4 (after $n_posts $section))  }}
+            <h2 class="f5 fw4 mb4 dib {{ cond (eq $.Site.Language.LanguageDirection "rtl") "ml3" "mr3" }}">
+              <a href="{{ .RelPermalink }}" class="link black dim">
+                {{ .Title }}
+              </a>
+            </h2>
+          {{ end }}
+
+          {{/* As above, Use $section_name to get the section title, and URL. Us e "with" to only show it if it exists */}}
+          {{ with $.Site.GetPage "section" $section_name }}
+            <a href="{{ .RelPermalink }}" class="link db f6 pa2 br3 bg-mid-gray white dim w4 tc">{{ i18n "allTitle" . }}</a>
+          {{ end }}
+          </section>
+        {{ end }}
+
+        </div>
+    {{ end }}
+  {{ end }}
+{{end}}

--- a/layouts/partials/summary-with-image.html
+++ b/layouts/partials/summary-with-image.html
@@ -1,0 +1,28 @@
+{{ $featured_image := partial "func/GetFeaturedImage.html" . }}
+<article class="bb b--black-10">
+  <div class="db pv4 ph3 ph0-l no-underline dark-gray">
+    <div class="flex flex-column flex-row-ns">
+      {{ if $featured_image }}
+          {{/* Trimming the slash and adding absURL make sure the image works no matter where our site lives */}}
+        <div class="{{ cond (eq $.Site.Language.LanguageDirection "rtl") "pl3-ns" "pr3-ns" }} mb4 mb0-ns w-100 w-40-ns">
+          <a href="{{.RelPermalink}}" class="db grow">
+            <img src="{{ $featured_image }}" class="img" alt="image from {{ .Title }}" style="height: 300px; object-fit: cover;">
+          </a>
+        </div>
+      {{ end }}
+      <div class="blah w-100{{ if $featured_image }} w-60-ns {{ cond (eq $.Site.Language.LanguageDirection "rtl") "pr3-ns" "pl3-ns" }}{{ end }}">
+        <h1 class="f3 fw1 athelas mt0 lh-title">
+          <a href="{{.RelPermalink}}" class="color-inherit dim link">
+            {{ .Title }}
+            </a>
+        </h1>
+        <div class="f6 f5-l lh-copy nested-copy-line-height nested-links">
+          {{ .Summary }}
+        </div>
+          <a href="{{.RelPermalink}}" class="ba b--moon-gray bg-light-gray br2 color-inherit dib f7 hover-bg-moon-gray link mt2 ph2 pv1">{{ $.Param "read_more_copy" | default (i18n "readMore") }}</a>
+        {{/* TODO: add author
+        <p class="f6 lh-copy mv0">By {{ .Author }}</p> */}}
+      </div>
+    </div>
+  </div>
+</article>


### PR DESCRIPTION
This change customizes the Ananke theme to display featured images for each post on the home page.

The `layouts/partials/summary-with-image.html` partial was overridden to add an inline style to the `<img>` tag, setting its height to 300px and `object-fit` to `cover`. This ensures the images are displayed uniformly and without distortion.

The `layouts/index.html` file was also overridden to use this modified partial.