### PR TITLE
feat: Configure GitHub Pages deployment

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,33 @@
+name: Deploy Hugo site to Pages
+
+on:
+  push:
+    branches:
+      - main # Set to your default branch
+  pull_request:
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true  # Fetch Hugo themes (true OR recursive)
+          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.124.1' # Specify a Hugo version
+
+      - name: Build
+        run: hugo --minify
+
+      - name: Deploy to GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          # cname: danicat.dev # Uncomment if you have a custom domain

--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@ This will generate the static site in the `public/` directory. The contents of t
 
 Many services like Netlify, Vercel, GitHub Pages, Cloudflare Pages, etc., can automatically build and deploy Hugo sites directly from a Git repository.
 
+### GitHub Pages Deployment
+
+This repository is configured to automatically build and deploy the website to GitHub Pages.
+- When changes are pushed to the `main` branch, a GitHub Actions workflow (defined in `.github/workflows/gh-pages.yml`) is triggered.
+- This workflow builds the Hugo site and deploys the generated static files (from the `public/` directory) to the `gh-pages` branch.
+- The site is then served from this `gh-pages` branch.
+
+**Custom Domain Configuration:**
+
+The site is configured with `baseURL: 'https://danicat.dev/'`. For this custom domain to work with GitHub Pages:
+1. The `gh-pages` branch must be selected as the publishing source in your repository's settings under "Pages".
+2. The custom domain `danicat.dev` must be configured in the same "Pages" settings section. You will also need to configure your DNS records with your domain registrar to point to GitHub Pages servers. Follow the [official GitHub Pages documentation](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site) for detailed instructions.
+
 ## License
 
 This project is licensed under the terms of the MIT License. See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
Adds a GitHub Actions workflow to automatically build and deploy the Hugo site to GitHub Pages.

The workflow:
- Triggers on pushes to the main branch and pull requests.
- Checks out the repository and its submodules.
- Sets up Hugo v0.124.1.
- Builds the site using `hugo --minify`.
- Deploys the content of the `public/` directory to the `gh-pages` branch.

Also includes:
- A `.gitattributes` file for consistent line endings.
- Updated `README.md` with instructions on the deployment process and custom domain configuration for GitHub Pages.