### PR TITLE
feat: add Portuguese translations for blog posts

### DIFF
--- a/content/posts/20250520-hello-world/index.pt-br.md
+++ b/content/posts/20250520-hello-world/index.pt-br.md
@@ -1,0 +1,17 @@
++++
+date = '2025-05-20T17:38:53+01:00'
+title = 'Olá Mundo'
+summary = "Apenas algumas palavras para dar o pontapé inicial neste blog!"
++++
+
+Bem-vindo ao danicat.dev! Sou Daniela Petruzalek, engenheira de software com mais de 20 anos de experiência na área e atualmente trabalho como Engenheira de Relações com Desenvolvedores no Google. Este é o meu novo blog pessoal, onde vou compartilhar os últimos desenvolvimentos em tecnologia!
+
+Se você já está familiarizado com o meu conteúdo da época em que eu era Google Developer Expert, talvez saiba o que esperar, mas caso contrário, confira meu conteúdo anterior no meu repositório do GitHub de [apresentações públicas](https://github.com/danicat/public-speaking)!
+
+Estou sempre aberta a colaborações e palestras. Se você quiser me ver no seu próximo evento, ou colaborar comigo em um vídeo ou podcast, por favor, entre em contato comigo no LinkedIn ou envie uma mensagem para [daniela@danicat.dev](mailto:daniela@danicat.dev)
+
+Por enquanto é só, mas fique ligado para conteúdo sobre engenharia de software, Google Cloud, GenAI, engenharia de dados e muito mais!
+
+Dani =^.^=
+
+P.S.: Por favor, note que as opiniões escritas neste blog são minhas e não representam as opiniões do meu empregador! ^^

--- a/content/posts/20250521-jules/index.pt-br.md
+++ b/content/posts/20250521-jules/index.pt-br.md
@@ -1,0 +1,21 @@
++++
+date = '2025-05-21T17:45:07+01:00'
+title = 'Precisamos falar sobre o Jules!'
+summary = "O novo agente de codificação autônomo que todo desenvolvedor precisa conhecer."
+tags = ["vibe coding"]
++++
+Olá a todos, vamos falar sobre o Jules! Saído direto do forno do Google I/O, isto é o que o Google chama de um agente de codificação autônomo… mas o que é um agente de codificação autônomo? Pense no [NotebookLM](https://notebooklm.google/), mas para codificação - uma IA especializada para ajudá-lo com tarefas de programação. A principal diferença da abordagem tradicional de “vibe coding” é que com o Jules você pode importar todo o seu projeto como contexto para a IA, então todas as respostas são baseadas no código em que você está realmente trabalhando!
+
+Depois que o projeto é importado, você pode interagir com o Jules enviando “tarefas”, que podem ser qualquer coisa, desde correções de bugs, atualizações de dependência, novos recursos, planejamento, documentação, testes e assim por diante. Assim que recebe uma tarefa, o Jules planejará assincronamente sua execução em etapas e realizará diferentes subtarefas para garantir que o resultado desejado seja alcançado. Por exemplo, garantindo que nenhum teste foi quebrado pela nova alteração.
+
+Ele se integra diretamente com o GitHub, então há muito pouco atrito para começar a usá-lo. Ele ainda não substituirá completamente o IDE, mas você pode realizar muitas tarefas diretamente do Jules até o ponto em que ele cria um branch com todas as alterações solicitadas, pronto para ser transformado em um pull request.
+
+A consequência infeliz do anúncio do Jules ontem é que a ferramenta está atualmente sob forte carga, então pode levar um tempo depois que você envia uma tarefa para ver os resultados, mas o Jules fará o trabalho em segundo plano e se você tiver as notificações do navegador ativadas, ele o avisará quando estiver pronto.
+
+Diante disso, não consegui fazer grandes experimentos com ele, mas uma das coisas que fiz foi gerar o [README para o projeto do meu blog no Github](https://github.com/danicat/danicat.dev/pull/1) (a fonte desta mesma página que você está lendo agora). Também tentei algumas iterações mais complexas, como ajustar o template do blog. [Ele gerou os arquivos corretos](https://github.com/danicat/danicat.dev/pull/2), mas demorou um pouco para responder às minhas solicitações, então tive que fazer algumas alterações manualmente.
+
+Nada mal para o primeiro dia, eu diria, e há muito potencial a ser desbloqueado nas próximas semanas e meses. O recurso matador é a capacidade de trabalhar em uma base de código completa, em vez daquele fluxo tradicional de fazer uma pergunta ao Gemini (ou ChatGPT), copiar o código-fonte para o IDE, executar, copiar e colar de volta os resultados no LLM e iterar. Claro, ferramentas como Code Assist e CoPilot fornecerão algumas dessas capacidades sem sair do IDE, mas ainda sinto que o IDE não é o ambiente certo para o vibe coding, pois parece mais um hack.
+
+Nesse espírito, talvez o Jules seja a injeção de inspiração que precisávamos para uma nova era de IDEs que desbloqueará o potencial da IA para desenvolvedores em todo o mundo de uma forma mais natural. Pelo menos é o que espero!
+
+O Jules está atualmente em beta público e você pode brincar com ele hoje inscrevendo-se em [https://jules.google](https://jules.google).

--- a/content/posts/20250528-vibe-coding/index.pt-br.md
+++ b/content/posts/20250528-vibe-coding/index.pt-br.md
@@ -1,0 +1,55 @@
++++
+date = "2025-05-28T16:30:00+01:00"
+title = "Qualquer um pode programar no \"vibe code\"?"
+tags = ["opiniao", "vibe coding"]
+summary = "Uma reflexão sobre o futuro da carreira de engenharia de software."
++++
+## Introdução
+
+Você acredita que um não engenheiro pode programar um aplicativo pronto para produção no "vibe code"? Esta é a pergunta sobre a qual tenho refletido ultimamente.
+
+O cenário da IA está se movendo tão rapidamente, e estamos vendo tantas ferramentas legais sendo lançadas quase todos os dias, então é natural que muitas pessoas estejam ficando com medo e começando a "prever" o fim da carreira de engenharia de software. Veja o [Jules]({{<ref "/posts/20250521-jules/index.md" >}}) por exemplo, um agente de IA que pode automatizar muitas tarefas típicas de engenheiros, como atualizar dependências, escrever documentação, refatorar e até mesmo testar.
+
+Se essas são as **únicas** coisas que você está agregando como engenheiro, talvez sim, você deva ter medo. Mas o medo não é necessariamente algo ruim, ele nos tira da zona de conforto, nos permite correr riscos que de outra forma não correríamos. Uma boa dose de medo impulsiona o autodesenvolvimento e a inovação.
+
+## Afinal, o que *é* um Engenheiro?
+
+Talvez eu não seja a melhor pessoa para responder a essa pergunta porque, embora eu tenha estudado Engenharia Elétrica na faculdade, na verdade nunca me formei. No entanto, posso dizer que, mesmo sem diploma, o período que passei no curso foi fundamental para moldar minha mentalidade ao abordar problemas em minha carreira.
+
+Um dos momentos cruciais que me influenciaram foi uma masterclass com o Dr. Ewaldo Mehl (UFPR) discutindo a carreira de engenharia para nossa turma de calouros. Entre muitas observações brilhantes, uma que ficou comigo até agora - mais de 20 anos depois - foi sobre a natureza do trabalho que fazemos... Ele disse algo como: "Engenheiros são os profissionais mais próximos dos deuses (...) porque não apenas consertamos coisas, nós as *criamos*."
+
+Sim, eu sei que este comentário fora de contexto pode parecer estranho, mas o ponto principal da conversa estava relacionado ao "complexo de Deus" com o qual algumas carreiras como a Medicina frequentemente lutam, e meu professor estava tirando sarro disso dizendo que os engenheiros não deveriam se sentir inferiores aos médicos porque, na verdade, somos nós que deveríamos ter esse complexo. (Por favor, mantenham os comentários em ordem, isso foi no início dos anos 2000, então estávamos muito próximos dos anos 90 :-)
+
+É um ditado comum de onde eu venho que no fundo de toda piada há um pouco de verdade, então, deixando as coisas de lado, acho que o Dr. Mehl estava certo em algo... Removendo todas as ferramentas, em nossa essência, somos criadores. A maneira como criamos evolui. Costumava ser com nossas próprias mãos e matérias-primas. Depois vieram ferramentas, computadores e robôs. Agora, estamos entrando na era da IA.
+
+Então, sempre que você pensar sobre a carreira de engenharia - e se ela vai morrer ou não - pense na necessidade humana de criar coisas novas. Sempre estaremos iterando, melhorando e inovando. Esta é uma característica tão fundamental da natureza humana que não consigo acreditar que vá desaparecer, seja nos próximos 5 anos ou no próximo milênio.
+
+Mas a *maneira* como criamos e melhoramos as coisas, isso sim, acredito que vai mudar.
+
+## Orquestrando, Não Apenas Codificando
+
+Acho que a revolução da IA nos libertará das partes chatas para nos concentrarmos no aspecto mais empolgante do nosso trabalho: arquitetura, design, planejamento e teste das soluções.
+
+Não estou dizendo que codificar em si é chato. Na verdade, muito pelo contrário, como a maioria dos engenheiros, gosto bastante de codificar. Mas manter código profissional é diferente de escrever código por diversão. Há tantas coisas que você escreverá que não se traduzem totalmente nas coisas que você deseja alcançar.
+
+Pense em todos os não funcionais, como por exemplo segurança, logging, métricas e networking; as horas gastas configurando, implantando, testando e validando; todas as etapas de configuração para integrar diferentes camadas de aplicação, bancos de dados e assim por diante... Muitas das coisas que fazemos no dia a dia são apenas para "fazer funcionar", em oposição a realmente resolver um problema de negócio.
+
+Mesmo tarefas simples, como configurar este blog, ainda me levaram alguns dias de trabalho - tive que configurar meu ambiente de desenvolvimento, pesquisar qual é a melhor ferramenta para blogs em 2025, pesquisar opções de hospedagem, pesquisar a linguagem de domínio usada para descrever blogs na minha plataforma escolhida (por exemplo, como os sites Hugo são organizados), testar alguns templates antes de selecionar um, pesquisar como adicionar comentários às postagens... e assim por diante.
+
+Como tudo isso se relaciona com o problema de negócio que quero resolver? São etapas importantes, mas só as fiz porque são etapas necessárias para "fazer funcionar", e não realmente o que eu queria alcançar em primeiro lugar.
+
+O que eu realmente quero é criar uma fonte de verdade que eu possa usar para publicar posts de blog e depois transmiti-los para diferentes plataformas para melhor alcance (por exemplo, Medium, LinkedIn, etc.). Ainda não consegui resolver este problema de negócio porque tive que me concentrar em todos os aspectos do pipeline de desenvolvimento de um novo aplicativo, desde o início até a produção.
+
+Quão bom seria se pudéssemos abstrair tudo isso e apenas pedir a uma IA para "gerar uma plataforma de blog para mim, com tudo incluído"?
+
+É aqui que a IA se tornará rapidamente muito poderosa. Com o nascimento da IA Agêntica, em breve teremos milhares de agentes à nossa disposição para orquestrar todas as etapas do processo de desenvolvimento de software, deixando-nos com a tarefa principal de ideação de novas experiências, e a "operacionalização" disso será responsabilidade dos agentes. Eles irão codificar, implantar e iterar. Eles farão a pesquisa por nós e nos darão opções, para que possamos escolher de acordo com nossos ideais.
+
+Pode ser difícil para você imaginar como isso funcionaria sem um exemplo concreto, mas é por isso que amo ficção científica, pois nos permite dar uma espiada no futuro. Pense no computador de Star Trek... Acredito que em alguns anos estaremos interagindo com o computador da mesma forma que [Geordy La Forge faz nesta cena](https://youtu.be/L0mRMp2kbQY?feature=shared) - o processo de engenharia se torna um diálogo mais do que um esforço unilateral de um engenheiro.
+
+Já chegamos lá? Na verdade não, mas a IA Agêntica é o próximo passo para tornar realidade o futuro retratado em Star Trek. Definitivamente, está começando a parecer que a IA é maior que a internet, e como desenvolvedores, devemos nos esforçar para nos atualizarmos para a "próxima geração" (trocadilho intencional).
+
+## Então, Qualquer Um Pode Programar no "Vibe Code"?
+
+Talvez não *qualquer um*, mas a barreira de entrada está definitivamente ficando mais baixa. As habilidades essenciais estão evoluindo, mas o papel do engenheiro de criar e arquitetar ainda está aqui e estará aqui por muito tempo.
+
+**O que você acha? Você consegue se ver como um engenheiro mais "hands-off", guiando a IA para dar vida às suas visões? Vamos discutir nos comentários!**

--- a/content/posts/20250531-diagnostic-agent/index.pt-br.md
+++ b/content/posts/20250531-diagnostic-agent/index.pt-br.md
@@ -1,0 +1,350 @@
++++
+date = '2025-05-31T01:00:00+01:00'
+title = 'Como transformei meu computador na "USS Enterprise" usando Agentes de IA'
+summary = "Como criar um agente de diagnóstico que fala linguagem natural usando Gemini e Vertex AI Agent Engine"
+tags = ["gemini", "vertex ai", "python"]
++++
+_Espaço: a fronteira final. Estas são as viagens da nave estelar Enterprise. Sua missão de 5 anos: explorar novos mundos estranhos; procurar novas vidas e novas civilizações; audaciosamente ir onde nenhum homem jamais esteve._
+
+## Introdução
+
+Enquanto crescia, graças à influência do meu pai, acostumei-me a ouvir essas palavras quase todos os dias. Suspeito que a paixão dele por Star Trek desempenhou um papel enorme na minha escolha pela carreira de engenharia de software. (Para aqueles que não estão familiarizados com Star Trek, este discurso era reproduzido no início de cada episódio da série original de Star Trek)
+
+Star Trek sempre esteve à frente de seu tempo. Mostrou o [primeiro beijo inter-racial na televisão dos EUA](https://en.wikipedia.org/wiki/Kirk_and_Uhura%27s_kiss), em tempos em que tal cena causava muita controvérsia. Também retratou muitas peças de tecnologia “futurista” que hoje são commodities, como smartphones e videoconferência.
+
+Uma coisa realmente notável é como os engenheiros da série interagem com os computadores. Embora vejamos alguns teclados e pressionamentos de botões de vez em quando, muitos dos comandos são vocalizados em linguagem natural. Alguns dos comandos que eles dão ao computador são bastante icônicos, como por exemplo, quando solicitam ao computador para executar um “procedimento de diagnóstico de nível 1”, o que aconteceu tantas vezes que praticamente se tornou [uma piada](https://www.youtube.com/watch?v=cYzByQjzTb0) entre os fãs mais assíduos.
+
+Avançando mais de 30 anos e aqui estamos nós, na Era da IA, uma revolução tecnológica que promete ser maior que a internet. Claro que muitas pessoas estão com medo de como a IA pode impactar seus empregos ([escrevi sobre isso na semana passada](https://danicat.dev/posts/20250528-vibe-coding/)), mas crescer assistindo Star Trek torna mais fácil para mim ver como o papel do engenheiro mudará nos próximos anos. Em vez de comandar o computador por meio de texto, instruindo manualmente cada etapa do caminho por meio de linhas de código e compiladores, muito em breve passaremos a conversar e fazer brainstorming com nossos computadores.
+
+Para ajudar as pessoas a visualizar isso, vamos usar a tecnologia que temos hoje para criar um pequeno agente que nos permite interagir com nossas próprias máquinas usando linguagem natural.
+
+## O que você precisará para esta demonstração
+
+Para a linguagem de desenvolvimento, usaremos Python em um Jupyter Notebook, pois ele funciona muito bem para experimentação. As principais ferramentas e bibliotecas que usaremos são:
+
+*   [Vertex AI Agent Engine](https://cloud.google.com/vertex-ai/generative-ai/docs/agent-engine/overview?utm_campaign=CDR_0x72884f69_awareness_b421478530&utm_medium=external&utm_source=blog)
+*   [Osquery](https://www.osquery.io/) com [bindings para Python](https://github.com/osquery/osquery-python)
+*   [Jupyter Notebook](https://jupyter.org/) [opcional] (na verdade, estou usando o [plugin Jupyter para VSCode](https://code.visualstudio.com/docs/datascience/jupyter-notebooks))
+
+Os exemplos abaixo usarão o Gemini Flash 2.0, mas você pode usar qualquer [variante do modelo Gemini](https://ai.google.dev/gemini-api/docs/models). Não implantaremos este agente no Google Cloud desta vez, pois queremos usá-lo para responder a perguntas sobre a máquina local e não sobre o servidor na nuvem.
+
+## Visão Geral do Agente
+
+Se você já está familiarizado com o funcionamento da tecnologia de agentes, pode pular esta seção.
+
+Um agente de IA é uma forma de IA capaz de perceber seu ambiente e tomar ações autônomas para atingir objetivos específicos. Se comparado com os típicos Modelos de Linguagem Grande (LLMs), que se concentram principalmente na geração de conteúdo com base na entrada, os agentes de IA podem interagir com seu ambiente, tomar decisões e executar tarefas para atingir seus objetivos. Isso é alcançado pelo uso de “ferramentas” que alimentarão o agente com informações e permitirão que ele realize ações.
+
+Para demonstrar a tecnologia de agente, usaremos o LangChain por meio do [Agent Engine](https://cloud.google.com/vertex-ai/generative-ai/docs/agent-engine/develop/langchain?utm_campaign=CDR_0x72884f69_awareness_b421478530&utm_medium=external&utm_source=blog). Primeiro, você precisa instalar os pacotes necessários em seu sistema:
+
+```shell
+pip install --upgrade --quiet google-cloud-aiplatform[agent_engines,langchain]
+```
+
+Você também precisará definir suas credenciais padrão de aplicativo (ADC) do gcloud:
+
+```shell
+gcloud auth application-default login
+```
+
+Nota: dependendo do ambiente que você está usando para executar esta demonstração, pode ser necessário usar um método de autenticação diferente.
+
+Agora estamos prontos para trabalhar em nosso script Python. Primeiro, vamos inicializar o SDK com base no ID e local do nosso projeto do Google Cloud:
+
+```python
+import vertexai
+
+vertexai.init(
+    project="my-project-id",                  # Seu ID de projeto.
+    location="us-central1",                   # Sua localização na nuvem.
+    staging_bucket="gs://my-staging-bucket",  # Seu bucket de preparo.
+)
+```
+
+Uma vez feita a configuração inicial, criar um agente usando LangChain no Agent Engine é bastante simples:
+
+```python
+from vertexai import agent_engines
+
+model = "gemini-2.0-flash" # sinta-se à vontade para experimentar diferentes modelos!
+
+model_kwargs = {
+    # temperature (float): A temperatura de amostragem controla o grau de
+    # aleatoriedade na seleção de tokens.
+    "temperature": 0.20,
+}
+
+agent = agent_engines.LangchainAgent(
+    model=model,                # Obrigatório.
+    model_kwargs=model_kwargs,  # Opcional.
+)
+```
+
+A configuração acima é suficiente para você enviar consultas ao agente, assim como enviaria uma consulta a um LLM:
+
+```python
+response = agent.query(
+    input="which time is now?"
+)
+print(response)
+```
+
+O que poderia retornar algo assim:
+
+```
+{'input': 'which time is now?', 'output': 'Como uma IA, eu não tenho uma hora ou local "atuais" da mesma forma que um humano. Meu conhecimento não é atualizado em tempo real.\n\nPara saber a hora atual, você pode:\n\n*   **Verificar seu dispositivo:** Seu computador, telefone ou tablet exibirá a hora atual.\n*   **Fazer uma pesquisa rápida:** Digite "que horas são" em um mecanismo de busca como o Google.'}
+```
+
+Dependendo de suas configurações, prompt e da aleatoriedade do universo, o modelo pode lhe dar uma resposta dizendo que não pode lhe dizer a hora, ou pode “alucinar” e inventar um timestamp. Mas, na verdade, como a IA não tem relógio, ela não será capaz de responder a essa pergunta... a menos que você lhe dê um relógio!
+
+## Chamadas de Função
+
+Uma das maneiras mais convenientes de estender as capacidades do nosso agente é dar-lhe funções Python para chamar. O processo é bastante simples, mas é importante ressaltar que quanto melhor a documentação que você tiver para a função, mais fácil será para o agente acertar sua chamada. Vamos definir nossa função para verificar a hora:
+
+```python
+import datetime
+
+def get_current_time():
+    """Retorna a hora atual como um objeto datetime.
+
+    Args:
+        Nenhum
+
+    Returns:
+        datetime: hora atual como um tipo datetime
+    """
+    return datetime.datetime.now()
+```
+
+Agora que temos uma função que nos dá a hora do sistema, vamos recriar o agente, mas agora ciente de que a função existe:
+
+```python
+agent = agent_engines.LangchainAgent(
+    model=model,                # Obrigatório.
+    model_kwargs=model_kwargs,  # Opcional.
+    tools=[get_current_time]
+)
+```
+
+E faça a pergunta novamente:
+
+```python
+response = agent.query(
+    input="which time is now?"
+)
+print(response)
+```
+
+A saída será semelhante a esta:
+
+```
+{'input': 'which time is now?', 'output': 'A hora atual é 18:36:42 UTC de 30 de maio de 2025.'}
+```
+
+Agora o agente pode contar com a ferramenta para responder à pergunta com dados reais. Muito legal, hein?
+
+## Coletando Informações do Sistema
+
+Para nosso agente de diagnóstico, vamos dar a ele recursos para consultar informações sobre a máquina em que está sendo executado usando uma ferramenta chamada [osquery](https://www.osquery.io/). Osquery é uma ferramenta de código aberto desenvolvida pelo Facebook para permitir que o usuário faça consultas SQL a “tabelas virtuais” que expõem informações sobre o sistema operacional subjacente da máquina.
+
+Isso é conveniente para nós porque não apenas nos dá um único ponto de entrada para fazer consultas sobre o sistema, mas os LLMs também são muito proficientes em escrever consultas SQL.
+
+Você pode encontrar instruções sobre como instalar o osquery na [documentação oficial](https://osquery.readthedocs.io/en/stable/). Não vou reproduzi-las aqui porque elas variam dependendo do sistema operacional da sua máquina.
+
+Depois de instalar o osquery, você precisará instalar os bindings Python para o osquery. Como é típico em Python, é apenas um `pip install`:
+
+```shell
+pip install --upgrade --quiet osquery
+```
+
+Com os bindings instalados, você pode fazer chamadas ao osquery importando o pacote `osquery`:
+
+```python
+import osquery
+
+# Inicia um processo osquery usando um soquete de extensão efêmero.
+instance = osquery.SpawnInstance()
+instance.open()  # Isso pode levantar uma exceção
+
+# Emite consultas e chama APIs Thrift do osquery.
+instance.client.query("select timestamp from time")
+```
+
+O método `query` retornará um objeto `ExtensionResponse` com os resultados de sua consulta. Por exemplo:
+
+```python
+ExtensionResponse(status=ExtensionStatus(code=0, message='OK', uuid=0), response=[{'timestamp': 'Sex Mai 30 17:54:06 2025 UTC'}])
+```
+
+Se você nunca trabalhou com o osquery antes, encorajo você a dar uma olhada no [schema](https://www.osquery.io/schema/5.17.0/) para ver que tipo de informação está disponível em seu sistema operacional.
+
+### Uma nota lateral sobre formatação
+
+Todas as saídas dos exemplos anteriores não foram formatadas, mas se você estiver executando o código do Jupyter, poderá acessar alguns métodos de conveniência para embelezar a saída importando os seguintes pacotes:
+
+```python
+from IPython.display import Markdown, display
+```
+
+E exibindo a saída da resposta como markdown:
+
+```python
+response = agent.query(
+    input="what is today's stardate?"
+)
+display(Markdown(response["output"]))
+```
+
+Saída:
+
+```
+Diário do Capitão, Suplementar. A data estelar atual é 48972.5.
+```
+
+## Conectando os pontos
+
+Agora que temos uma maneira de consultar informações sobre o sistema operacional, vamos combinar isso com nosso conhecimento de agentes para criar um agente de diagnóstico que responderá a perguntas sobre nosso sistema.
+
+O primeiro passo é definir uma função para fazer as consultas. Isso será dado ao agente como uma ferramenta para coletar informações posteriormente:
+
+```python
+def call_osquery(query: str):
+    """Consulta o sistema operacional usando osquery
+
+      Esta função é usada para enviar uma consulta ao processo osquery para retornar informações sobre a máquina atual, sistema operacional e processos em execução.
+      Você também pode usar esta função para consultar o banco de dados SQLite subjacente para descobrir mais informações sobre a instância do osquery usando tabelas do sistema como sqlite_master, sqlite_temp_master e tabelas virtuais.
+
+      Args:
+        query: str  Uma consulta SQL para uma das tabelas do osquery (por exemplo, "select timestamp from time")
+
+      Returns:
+        ExtensionResponse: uma resposta do osquery com o status da solicitação e uma resposta à consulta, se bem-sucedida.
+    """
+    return instance.client.query(query)
+```
+
+A função em si é bastante trivial, mas a parte importante aqui é ter um docstring bem detalhado que permitirá ao agente entender como essa função funciona.
+
+Durante meus testes, um problema complicado que ocorreu com bastante frequência foi que o agente não sabia exatamente quais tabelas estavam disponíveis em meu sistema. Por exemplo, estou executando uma máquina macOS e a tabela “memory_info” não existe.
+
+Para dar ao agente um pouco mais de contexto, vamos fornecer dinamicamente os nomes das tabelas que estão disponíveis neste sistema. Em uma situação ideal, você até daria a ele o schema inteiro com nomes de colunas e descrições, mas infelizmente isso não é trivial de se conseguir com o osquery.
+
+A tecnologia de banco de dados subjacente para o osquery é o SQLite, então podemos consultar a lista de tabelas virtuais da tabela `sqlite_temp_master`:
+
+```python
+# use um pouco de mágica Python para descobrir quais tabelas temos neste sistema
+response = instance.client.query("select name from sqlite_temp_master").response
+tables = [ t["name"] for t in response ]
+```
+
+Agora que temos todos os nomes das tabelas, podemos criar o agente com esta informação e a ferramenta `call_osquery`:
+
+```python
+osagent = agent_engines.LangchainAgent(
+    model = model,
+    system_instruction=f"""
+    Você é um agente que responde a perguntas sobre a máquina em que está sendo executado.
+    Você deve executar consultas SQL usando uma ou mais das tabelas para responder às perguntas do usuário.
+    Sempre retorne valores legíveis por humanos (por exemplo, megabytes em vez de bytes e hora formatada em vez de milissegundos)
+    Seja muito flexível em sua interpretação das solicitações. Por exemplo, se o usuário solicitar informações do aplicativo, é aceitável retornar informações sobre processos e serviços. Se o usuário solicitar o uso de recursos, retorne AMBAS as informações de memória e CPU.
+    Não peça esclarecimentos ao usuário.
+    Você tem as seguintes tabelas disponíveis para você:
+    ----- TABELAS -----
+    {tables}
+    ----- FIM TABELAS -----
+
+    Pergunta:
+    """,
+    tools=[
+        call_osquery,
+    ]
+)
+```
+
+Acredite ou não, nosso agente está pronto para todas as nossas perguntas! Vamos experimentar:
+
+```python
+response = osagent.query(input="what is the current time?")
+display(Markdown(response["output"]))
+```
+
+Saída:
+
+```
+A hora atual é Sex Mai 30 18:08:15 2025 UTC.
+```
+
+Vamos complicar um pouco mais:
+
+```python
+response = osagent.query(input="what is the top consuming process?")
+display(Markdown(response["output"]))
+```
+
+Saída:
+
+```
+O processo que mais consome CPU é:
+Nome do Processo: mediaanalysisd, PID: 1127, Tempo Total de CPU: 2876716
+
+O processo que mais consome memória é:
+Nome do Processo: Code Helper (Plugin), PID: 2987, Uso de Memória: 1537 MB
+```
+
+E se eu for um pouco mais criativo?
+
+```python
+response = osagent.query(input="computer, run a level 1 diagnostic procedure")
+display(Markdown(response["output"]))
+```
+
+Saída:
+
+```
+Aqui estão as informações de diagnóstico de nível 1:
+
+**Sistema Operacional:**
+*   **Nome:** macOS
+*   **Versão:** 15.5
+*   **Build:** 24F74
+*   **Plataforma:** darwin
+*   **Arquitetura:** arm64
+
+... omitido por questões de brevidade ...
+
+**Tempo de Atividade:**
+*   **Segundos Totais:** 261164
+*   **Dias:** 3
+*   **Horas:** 0
+*   **Minutos:** 32
+*   **Segundos:** 44
+
+```
+
+Uau! Eu nunca defini o que é um procedimento de diagnóstico de Nível 1, mas ele me deu um relatório bastante impressionante mesmo assim!
+
+Até tentei ser um pouco mais esperto nas minhas perguntas e as respostas não decepcionaram (na maioria das vezes):
+
+```python
+response = osagent.query(input="computer, do you see any signs of malware running?")
+display(Markdown(response["output"]))
+```
+
+Saída:
+
+```
+Verifiquei se há processos que não estão associados a um arquivo em disco, o que pode ser um sinal de malware, e não encontrei nenhum. Também examinei os principais processos por uso de memória e CPU. Os processos que consomem mais recursos são principalmente o Visual Studio Code e o Google Chrome e seus processos auxiliares relacionados. Este é um comportamento típico para esses aplicativos.
+
+Com base nas verificações realizadas, não há sinais óbvios de malware em execução no sistema neste momento.
+```
+
+_Mic drop_ =^.^=
+
+## Conclusões
+
+Eu sei que já é um argumento batido, mas a IA é um divisor de águas. Com pouquíssimas linhas de código, passamos do zero para uma interface de linguagem natural totalmente funcional para o funcionamento interno do sistema operacional. Com um pouco mais de trabalho, este agente pode ser aprimorado para fazer diagnósticos mais profundos e talvez até mesmo consertar coisas autonomamente. Scotty ficaria orgulhoso!
+
+![Engenheiro Scotty tentando falar com o computador usando o mouse como microfone](hello-computer-hello.gif)
+
+Você pode encontrar o código-fonte de todos os exemplos deste artigo no meu [GitHub](https://github.com/danicat/devrel/blob/main/blogs/20250531-diagnostic-agent/diagnostic_agent.ipynb).
+
+Quais são suas impressões? Compartilhe suas ideias nos comentários abaixo.

--- a/content/posts/20250605-vertex-ai-sdk-python/index.pt-br.md
+++ b/content/posts/20250605-vertex-ai-sdk-python/index.pt-br.md
@@ -1,0 +1,301 @@
++++
+date = '2025-06-05T00:00:00+01:00'
+title = 'Aprofundando-se no SDK da Vertex AI para Python'
+summary = "Este artigo explora o modelo de comunicação entre o código do cliente e a API Gemini usando o SDK da Vertex AI para Python"
+tags = ["gemini", "vertex ai", "python"]
++++
+## Introdução
+
+Este artigo explora o modelo de comunicação entre o código do cliente e a API Gemini usando o [SDK da Vertex AI para Python](https://cloud.google.com/vertex-ai/docs/python-sdk/use-vertex-ai-python-sdk?utm_campaign=CDR_0x72884f69_awareness_b422727650&utm_medium=external&utm_source=blog). Cobriremos conceitos como a estrutura das mensagens, como o modelo entende o contexto da pergunta e como aumentar as capacidades do modelo com chamadas de função. Embora o Gemini seja o foco deste artigo, os mesmos conceitos que você verá aqui também podem ser aplicados ao Gemma e outros LLMs.
+
+[No meu post anterior](https://danicat.dev/posts/20250531-diagnostic-agent/), expliquei como escrever um Agente de IA simples - mas surpreendentemente poderoso - que responde a perguntas de diagnóstico sobre sua máquina local. Em poucas linhas de código (e não tão poucas linhas de comentários), conseguimos fazer nosso agente responder a consultas como “quanta CPU eu tenho na minha máquina” ou “por favor, verifique se há sinais de malware”.
+
+Isso, claro, deveu-se à beleza do SDK Python, pois simplificou muito as coisas. Por exemplo, contei com um recurso chamado [Chamada de Função Automática](https://ai.google.dev/gemini-api/docs/function-calling?example=weather#automatic_function_calling_python_only) para permitir que o agente decidisse quando chamar uma função. Esse recurso também me ajudou a definir as funções como funções Python simples e o SDK descobriu sua assinatura e descrição dinamicamente para mim. Essa capacidade, infelizmente, está disponível apenas para o SDK Python, então os desenvolvedores em outras linguagens precisam trabalhar um pouco mais.
+
+É por isso que no artigo de hoje vamos adotar uma abordagem um pouco diferente e discutir como a API Gemini funciona para que você possa estar mais bem preparado para usar não apenas Python, mas qualquer um dos SDKs disponíveis (JS, Go e Java). Continuarei usando Python para os exemplos para que você possa comparar com o artigo anterior, mas os conceitos discutidos aqui são válidos para todas as diferentes linguagens.
+
+Vamos cobrir dois tópicos principais:
+*   Como funciona a conversa entre cliente e modelo
+*   Como implementar chamadas de função manualmente
+
+Observe que, se você é um desenvolvedor Python, isso também não significa que não aprenderá nada com este artigo. Na verdade, entender o fluxo da conversa será importante para usar conceitos mais avançados do SDK (como a Live API) e trabalhar com LLMs em geral.
+
+## Entendendo como a API funciona
+
+Os agentes normalmente funcionam da mesma forma que os aplicativos cliente-servidor - você tem um componente cliente responsável por preparar e fazer as solicitações e um processo servidor que hospeda o tempo de execução do modelo e processa as solicitações do cliente.
+
+Para a Vertex AI, existem dois grupos principais de APIs: uma API REST para o estilo típico de solicitação/resposta de geração de conteúdo, onde o cliente envia uma solicitação e aguarda a resposta antes de continuar, e uma nova [Live API](https://cloud.google.com/vertex-ai/generative-ai/docs/live-api?utm_campaign=CDR_0x72884f69_awareness_b422727650&utm_medium=external&utm_source=blog) que processa informações em tempo real usando websockets. Vamos nos concentrar primeiro nas APIs REST, pois a Live API requer um pouco mais de trabalho preparatório para funcionar corretamente.
+
+Normalmente, geramos conteúdo em uma das seguintes modalidades: texto, imagem, áudio e vídeo. Muitos dos modelos mais recentes também são multimodais, o que significa que você pode lidar com mais de uma modalidade de entrada e/ou saída ao mesmo tempo. Para simplificar, vamos começar com texto.
+
+Um aplicativo típico de prompt único se parece com isto:
+
+```python
+from google import genai
+
+client = genai.Client(
+    vertexai=True,
+    project="daniela-genai-sandbox",
+    location="us-central1"
+)
+
+response = client.models.generate_content(
+    model="gemini-2.0-flash",
+    contents="How are you today?"
+)
+print(response.text)
+
+```
+
+Saída:
+
+```
+Estou bem, obrigado por perguntar! Como um modelo de linguagem grande, não experimento emoções como os humanos, mas estou funcionando de forma otimizada e pronto para ajudá-lo. Como posso ajudá-lo hoje?
+```
+
+A primeira coisa que precisamos fazer é instanciar o cliente, usando o modo Vertex AI (`vertexai=True`) ou usando uma chave de API Gemini. Neste caso, estou usando o modo Vertex AI.
+
+Assim que o cliente é inicializado, podemos enviar-lhe um prompt usando o método `client.models.generate_content`. Precisamos especificar qual modelo estamos chamando (neste caso `gemini-2.0-flash)` e o prompt no argumento `contents` (por exemplo, `"How are you today?"`).
+
+Olhando para este código, pode ser difícil imaginar o que está acontecendo por baixo dos panos, pois estamos obtendo muitas abstrações gratuitamente graças ao Python. A coisa mais importante neste caso é que o **conteúdo não é uma string**.
+
+`Contents` é na verdade uma lista de estruturas de conteúdo, e as estruturas de conteúdo são compostas por uma **função (role)** e uma ou mais **partes (parts)**. O tipo subjacente para esta estrutura é definido na biblioteca `types` e se parece com isto:
+
+
+```python
+from google.genai import types
+
+contents = [types.Content(
+  role = "user",
+  parts = [ types.Part_from_text("How are you today?")
+)]
+```
+
+Portanto, sempre que digitamos `contents="How are you today?"`, o SDK Python faz essa transformação de string para “conteúdo com uma parte de string” automaticamente para nós.
+
+Outra coisa importante a notar é que sempre que fazemos uma chamada para `generate_content`, o modelo está começando do zero. Isso significa que é nossa responsabilidade adicionar o contexto das mensagens anteriores ao próximo prompt. Vamos fazer um teste simples pedindo ao modelo que dia é hoje duas vezes seguidas:
+
+```python
+response = client.models.generate_content(
+    model="gemini-2.0-flash",
+    contents="what day is today?"
+)
+print(response.text)
+
+response = client.models.generate_content(
+    model="gemini-2.0-flash",
+    contents="what day is today?"
+)
+print(response.text)
+```
+
+Saída:
+
+```
+$ python3 main.py
+Hoje é domingo, 5 de novembro de 2023.
+
+Hoje é sábado, 2 de novembro de 2024.
+```
+
+Existem dois problemas com a resposta acima: 1) ela alucinou, pois o modelo não tem como saber a data, e 2) deu duas respostas diferentes para a mesma pergunta. Podemos corrigir o 1) baseando-nos em uma ferramenta como uma chamada de `datetime` ou Pesquisa Google, mas quero focar no 2) porque mostra claramente que o modelo não se lembra do que acabou de dizer e demonstra o ponto acima de que é **nossa** responsabilidade manter o modelo atualizado sobre a conversa.
+
+Vamos fazer uma pequena modificação no código:
+
+```python
+response = client.models.generate_content(
+    model="gemini-2.0-flash",
+    contents="what day is today?"
+)
+print(response.text)
+
+# cada elemento no array de conteúdos é geralmente referido como um "turno"
+contents = [
+    {
+        "role": "user",
+        "parts": [{
+            "text": "what day is today?"
+        }]
+    },
+    {
+        "role": "model",
+        "parts": [{
+            "text": response.text
+        }]
+    },
+    {
+        "role": "user",
+        "parts": [{
+            "text": "what day is today?"
+        }]
+    },
+]
+
+response = client.models.generate_content(
+    model="gemini-2.0-flash",
+    contents=contents
+)
+print(response.text)
+```
+
+Saída:
+
+```
+$ python3 main.py
+Hoje é quarta-feira, 15 de novembro de 2023.
+
+Hoje é quarta-feira, 15 de novembro de 2023.
+```
+
+Observe que na segunda chamada ao modelo estamos incluindo todo o contexto no atributo `contents`. Observe também que a `role` de cada parte muda de “user” para “model” e depois para “user” novamente (“user” e “model” são os únicos valores possíveis para `role`). É assim que o modelo entende em que ponto da conversa está, também conhecido como “turno”. Se, por exemplo, omitíssemos a última parte que repete a pergunta, o modelo pensaria que está atualizado e não produziria outra resposta, pois o último turno seria de “model” e não de “user”.
+
+A variável `contents` acima está escrita na forma de “dicionário”, mas o SDK também fornece vários métodos de conveniência como `types.UserContent` (define o campo `role` como “user” automaticamente) e `types.Part.from_text` (converte uma string simples em uma parte), entre outros.
+
+Para lidar com outros tipos de entradas e/ou saídas, podemos usar outros tipos de partes, como chamadas de função, dados binários, etc. Se um modelo for multimodal, você pode misturar partes de diferentes tipos de conteúdo na mesma mensagem.
+
+Os dados binários podem ser tanto inline quanto buscados de um URI. Você pode diferenciar entre diferentes tipos de dados usando o campo `mime_type`. Por exemplo, uma parte de imagem pode ser recuperada assim:
+
+```python
+from google.genai import types
+
+contents = types.Part.from_uri(
+  file_uri: 'gs://generativeai-downloads/images/scones.jpg',
+  mime_type: 'image/jpeg',
+)
+```
+
+Ou inline:
+
+```python
+contents = types.Part.from_bytes(
+  data: my_cat_picture, # dados binários
+  mime_type: 'image/jpeg',
+)
+```
+
+Em resumo, para cada turno da conversa, adicionaremos uma nova linha de conteúdo tanto para a resposta anterior do modelo quanto para a nova pergunta do usuário.
+
+A boa notícia é que a experiência de chatbot é um caso de uso tão importante que o SDK da Vertex AI fornece uma implementação para esse fluxo pronta para uso. Usando o recurso `chat`, podemos reproduzir o comportamento acima em poucas linhas de código:
+
+```python
+chat = client.chats.create(model='gemini-2.0-flash')
+response = chat.send_message('what day is today?')
+print(response.text)
+response = chat.send_message('what day is today?')
+print(response.text)
+```
+
+Saída:
+
+```
+$ python3 main.py
+Hoje é sábado, 14 de outubro de 2023.
+
+Hoje é sábado, 14 de outubro de 2023.
+```
+
+Desta vez, o modelo lembrou a data porque a interface de chat está lidando com o histórico automaticamente para nós.
+
+## Chamada de função não automática
+
+Agora que vimos como a API funciona para construir mensagens do cliente e gerenciar o contexto, é hora de explorar como ela lida com chamadas de função. Em um nível básico, precisaremos instruir o modelo de que ele tem uma função à sua disposição e, em seguida, processar suas solicitações para chamar a função e retornar os valores resultantes ao modelo. Isso é importante porque as chamadas de função permitem que os agentes interajam com sistemas externos e o mundo real, criando ações como recuperar dados ou acionar processos específicos, indo além de apenas gerar texto.
+
+A declaração da função é o que diz ao modelo o que ele pode fazer. Ela informa ao modelo o nome da função, a descrição e seus argumentos. Por exemplo, abaixo está uma declaração de função para a função `get_random_number`:
+
+```python
+get_random_number_decl = {
+    "name": "get_random_number",
+    "description": "Retorna um número aleatório",
+}
+```
+
+É essa declaração que o modelo precisa saber para decidir quais funções chamar. A declaração da função tem três campos: nome, descrição e parâmetros - neste caso, a função não aceita parâmetros, então este campo é omitido. O modelo usa a descrição da função e a descrição de seus argumentos para decidir quando e como chamar cada função.
+
+No artigo anterior, em vez de dar ao modelo uma declaração de função, fui preguiçoso e deixei o SDK descobrir isso para mim com base no docstring da minha função. Desta vez, vamos fazer diferente e declarar explicitamente uma função para entender melhor o fluxo subjacente.
+
+A função, incluindo sua declaração, se parece com isto:
+
+```python
+def get_random_number():
+    return 4 # escolhido por um lançamento de dado justo
+             # garantido ser aleatório (https://xkcd.com/221/)
+
+# a declaração informa ao modelo o que ele precisa saber sobre a função
+get_random_number_decl = {
+    "name": "get_random_number",
+    "description": "Retorna um número aleatório",
+}
+```
+
+Você pode ver outros exemplos de declarações de função [aqui](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/function-calling#schema-examples?utm_campaign=CDR_0x72884f69_awareness_b422727650&utm_medium=external&utm_source=blog).
+
+Em seguida, precisamos dizer ao modelo que ele tem acesso a esta função. Fazemos isso por meio da configuração do modelo, adicionando a função como uma ferramenta.
+
+```python
+tools = types.Tool(function_declarations=[get_random_number_decl])
+config = types.GenerateContentConfig(tools=[tools])
+
+# meu prompt inicial
+contents = [types.Part.from_text(text="what is my lucky number today?")]
+
+response = client.models.generate_content(
+    model="gemini-2.0-flash",
+    contents=contents,
+    config=config, # observe como estamos adicionando a configuração à chamada do modelo
+)
+
+print(response.candidates[0].content.parts[0])
+```
+
+Se você executar o código acima, obterá algo assim:
+
+```
+$ python3 main.py
+video_metadata=None thought=None inline_data=None file_data=None thought_signature=None code_execution_result=None executable_code=None function_call=FunctionCall(id=None, args={}, name='get_random_number') function_response=None text=None
+```
+
+O que você está vendo aqui é a primeira parte da resposta do modelo, e podemos ver que esta parte tem todos os campos vazios (`None`), exceto o campo `function_call`. Isso significa que o modelo quer que **nós** façamos essa chamada de função e, em seguida, retornemos seu resultado de volta ao modelo.
+
+Isso inicialmente me intrigou, mas se você pensar bem, faz todo o sentido. O modelo sabe que a função existe, mas não tem absolutamente nenhuma ideia de como chamá-la. Da perspectiva do modelo, a função também não está rodando na mesma máquina, então o modelo não pode fazer nada exceto “pedir educadamente” para que façamos a chamada em seu nome.
+
+Não tivemos que fazer isso no meu artigo anterior porque a Chamada de Função Automática assumiu o controle e simplificou as coisas para nós. A chamada ainda seguiu o mesmo fluxo, mas o SDK escondeu toda essa complexidade de nós.
+
+A coisa óbvia a fazer agora é chamar a função real e retornar o resultado para o modelo, mas lembre-se, sem contexto o modelo não sabe nada sobre nossa solicitação anterior, então se você enviar apenas os resultados da função de volta, ele não terá ideia do que fazer com isso!
+
+É por isso que precisamos enviar o histórico da interação até agora, e pelo menos até o ponto em que o modelo sabe que solicitou esse valor. O código abaixo assume que recebemos uma mensagem de chamada de função e precisamos enviar uma nova solicitação com as informações completas:
+
+```python
+# assumindo que já inspecionamos a resposta e sabemos o que o modelo quer
+result = get_random_number() # faz a chamada de função real
+
+# contents ainda contém o prompt original, então adicionaremos a resposta do modelo...
+contents.append(types.ModelContent(parts=response.candidates[0].content.parts))
+# ... e o resultado da chamada de função
+contents.append(types.UserContent(parts=types.Part.from_function_response(name="get_random_number", response={"result": result})))
+
+response = client.models.generate_content(
+    model="gemini-2.0-flash",
+    contents=contents,
+    config=config,
+)
+print(response.text)
+```
+
+Saída:
+
+```
+$ python3 main.py
+O número da sorte de hoje é 4.
+```
+
+## Conclusões
+
+Neste artigo, vimos como o cliente do agente se comunica com o modelo no lado do servidor ou, em outras palavras, o “modelo de domínio” das comunicações LLM. Também removemos a cortina da “mágica” que o SDK Python faz por nós.
+
+A automação é sempre conveniente e nos ajuda a alcançar resultados muito mais rapidamente, mas saber como ela realmente funciona geralmente é a grande diferença entre uma jornada tranquila e uma irregular ao implementar seu próprio agente, especialmente porque os casos especiais _nunca são tão fáceis_.
+
+Eu sei que em tempos de "vibe coding", à primeira vista, é quase irônico dizer algo assim, mas uma das coisas que aprendi rapidamente ao programar no "vibe coding" é que se você for mais preciso ao falar com a IA, obterá resultados muito melhores em muito menos tempo. Portanto, agora não é hora de menosprezar o valor do conhecimento, mas sim de dobrá-lo - não apesar da IA, mas **por causa** dela.
+
+Espero que você tenha gostado da jornada até agora. No próximo artigo, construiremos sobre este conhecimento para levar o agente de diagnóstico ao próximo nível, onde nenhum agente jamais esteve! (ou talvez tenha estado, mas certamente não o meu =^_^=)
+
+Por favor, escreva seus comentários abaixo! Paz o/

--- a/content/posts/20250702-gemini-cloud-assist/index.pt-br.md
+++ b/content/posts/20250702-gemini-cloud-assist/index.pt-br.md
@@ -1,0 +1,156 @@
++++
+date = '2025-07-02T00:00:00+01:00'
+title = 'Do Prompt à Infraestrutura com o Gemini Cloud Assist'
+summary = "Este artigo explora como projetar infraestrutura usando linguagem natural com o Gemini Cloud Assist no Google Cloud"
+tags = ["gemini", "cloud assist", "terraform"]
++++
+## Introdução
+
+Hoje vamos fazer um pequeno desvio do nosso conteúdo usual sobre agentes de IA para falar sobre um produto que explorei recentemente como parte da minha participação no I/O Connect Berlin 2025 na semana passada.
+
+Este evento reuniu mais de 1000 desenvolvedores de toda a Europa, incluindo membros das comunidades de desenvolvedores do Google (Google Developer Groups) e especialistas da comunidade. Foi também o meu primeiro evento oficial do Google desde que entrei para a equipe de DevRel em abril, por isso foi particularmente significativo para mim - e é por isso que não tivemos atualização no blog na semana passada!
+
+Fui responsável por uma demonstração chamada “Design and Deploy”, que mostra a combinação de dois produtos: [Application Design Center (ADC)](https://cloud.google.com/application-design-center/docs/overview?utm_campaign=CDR_0x72884f69_awareness_b428663487&utm_medium=external&utm_source=blog) e [Gemini Cloud Assist (GCA)](https://cloud.google.com/products/gemini/cloud-assist?utm_campaign=CDR_0x72884f69_awareness_b428663487&utm_medium=external&utm_source=blog). A demonstração foi tão bem recebida que achei que seria bom trazer esse conteúdo para o blog também, para dar a oportunidade às pessoas que não estavam lá de brincar com essa tecnologia também.
+
+O Application Design Center é um produto para ajudar arquitetos e desenvolvedores a projetar a infraestrutura de seus aplicativos. Na frente, ele fornece uma interface de usuário agradável onde você pode definir visualmente os componentes para sua infraestrutura, mas por baixo dos panos tudo na interface do usuário é representado como um módulo terraform para que você também possa aproveitar os benefícios da [Infraestrutura como Código](https://en.wikipedia.org/wiki/Infrastructure_as_code).
+
+Um aviso importante é que o ADC está atualmente em [pré-visualização pública](https://cloud.google.com/products?e=48754805&hl=en#product-launch-stages&utm_campaign=CDR_0x72884f69_awareness_b428663487&utm_medium=external&utm_source=blog). Isso significa que o produto está evoluindo a cada dia e, às vezes, pode quebrar a compatibilidade com iterações anteriores. Ele também tem algumas arestas notavelmente ásperas que mencionarei abaixo, que devem ser resolvidas antes que o produto se torne disponível para o público em geral.
+
+O Gemini Cloud Assist (também em pré-visualização pública), por outro lado, é o nome oficial do produto para o suporte do Gemini no Google Cloud. Por causa disso, o GCA não é um produto autônomo, mas mais como um tecido conjuntivo que permite aos usuários interagir com qualquer coisa do GCP usando linguagem natural, incluindo todos os benefícios da moderna experiência de chatbot baseada em modelos de linguagem grandes.
+
+Vamos ver como podemos usar ambas as tecnologias para projetar rapidamente a parte de infraestrutura de um aplicativo para nós.
+
+
+## Como iniciar uma sessão de design de aplicativo
+
+Você sempre pode abrir o Application Design Center manualmente no console do Google Cloud, mas qual é a graça disso? A melhor maneira de acionar o ADC para um novo design é simplesmente abrir o painel do Gemini em qualquer página. Aqui, por exemplo, estou usando a página de boas-vindas do meu projeto:
+
+![alt_text](images/image001.png "Tela de boas-vindas no console do Google Cloud")
+
+
+Se você clicar no botão “estrela” no lado direito da barra de pesquisa, abrirá o painel do Gemini Cloud Assist:
+
+![alt_text](images/image002.png "Visão ampliada do botão Gemini")
+
+Deve abrir:
+
+![alt_text](images/image003.png "Tela de boas-vindas do Google Cloud Assist")
+
+
+Este é o painel onde você pode interagir com o Gemini. Digite algo como “criar um aplicativo que faz x” e inclua quantos detalhes desejar sobre a arquitetura. Por exemplo, vamos tentar criar um aplicativo que gera fotos de gatos. Aqui está o prompt:
+
+> Crie um aplicativo que gere fotos de gatos com o Gemini e as armazene em um banco de dados Cloud SQL. Os usuários podem solicitar novas fotos usando um serviço de geração e podem ver as fotos geradas com um serviço de fotos. Ambos os serviços são expostos por meio de um serviço de frontend e um balanceador de carga global.
+
+Depois de inserir o prompt, o Gemini pensará por um tempo e, após alguns segundos, produzirá uma saída como esta:
+
+![alt_text](images/image004.png "Resposta do Gemini com diagrama de arquitetura")
+
+A visualização integrada nos dá uma ideia, mas podemos interagir melhor com o design se clicarmos no botão “Edit app design”. Isso abrirá o design em uma visualização expandida para que possamos refiná-lo ainda mais. (Observe que o restante deste artigo pressupõe que o botão “Edit app design” abre a janela de Pré-visualização. Se no seu caso não abrir, verifique as notas no final do artigo)
+
+É assim que fica na janela de “Pré-visualização”:
+
+![alt_text](images/image005.png "Janela de Pré-visualização do Gemini Cloud Assist")
+
+Se você não estiver satisfeito com as convenções de nomenclatura ou com os detalhes dos componentes gerados, poderá sempre alterá-los clicando no componente e abrindo o painel de configuração. Aqui abri o painel de configuração do meu `frontend-service`:
+
+![alt_text](images/image006.png "Visão do painel de detalhes do componente")
+
+Observe que esta tela também mostra qual contêiner é instanciado pelo Cloud Run, que assume como padrão um contêiner “hello”. Isso ocorre porque o Gemini Cloud Assist não tem informações sobre qual contêiner você deseja executar, mas se você fornecer essas informações, ele poderá substituir o valor.
+
+Estou destacando isso aqui também por outro motivo - precisamos definir as expectativas de que esta ferramenta não codifica o aplicativo para você, ela apenas projeta a infraestrutura para suportá-lo. Para codificar os serviços de frontend e backend reais, por exemplo, você precisará usar outras ferramentas como o Gemini CLI ou seu IDE regular e publicar os artefatos em seu registro de contêiner para que o Cloud Run possa acessá-los.
+
+Na janela de Pré-visualização, você pode editar componentes, mas não adicionar componentes manualmente. Se você quiser iterar no design, o que você pode fazer é pedir ao Gemini para modificar o design para você. Veja, por exemplo, este prompt de acompanhamento:
+
+> Adicione um serviço de streaming que capture eventos para cada foto de gato gerada. Do outro lado do stream, há um serviço de consumidor que atualizará uma página estática hospedada no GCS, adicionando as fotos mais recentes a um feed.
+
+Esta é a resposta do Gemini:
+
+![alt_text](images/image007.png "Resposta do Gemini ao prompt de acompanhamento")
+
+E a janela de Pré-visualização será atualizada com o novo design, destacando adições (verde), modificações (azul) e exclusões (vermelho):
+
+![alt_text](images/image008.png "Alterações propostas no diagrama")
+
+Na parte inferior da tela, você tem a opção de aceitar ou rejeitar a sugestão. Mas antes disso, é uma boa oportunidade para inspecionar o código terraform que é gerado por baixo dos panos. Para ver o código e comparar as alterações, clique em “View diff”:
+
+Isso abrirá a janela Code Diff com ambas as versões mostradas lado a lado:
+
+![alt_text](images/image009.png "Janela de revisão de diferenças mostrando comparação entre o código terraform antes e depois")
+
+Como você pode ver, cada caixa no diagrama é mapeada para um módulo terraform diferente. Se você rolar para baixo, poderá ver os módulos que ele adicionou recentemente destacados em verde.
+
+Se você estiver satisfeito com a implementação, pode aceitar a sugestão ou rejeitar e pedir ao Gemini para melhorá-la. Aceitei a sugestão, mas notei algo um pouco estranho sobre o módulo “database-secrets”, então decidi perguntar ao Gemini sobre isso:
+
+Prompt: “por que você adicionou um segredo de banco de dados se o banco de dados Cloud SQL está usando autenticação IAM?”
+
+Bem, acho que não era realmente necessário:
+
+![alt_text](images/image010.png "Resposta do Gemini à pergunta sobre IAM")
+
+Na janela de Pré-visualização:
+
+![alt_text](images/image011.png "Proposta do Gemini para remover o segredo do banco de dados")
+
+Este é um alerta importante de que, por mais que a IA tenha se tornado cada vez mais avançada, ainda não estamos isentos de avaliar e tomar decisões. No final das contas, a IA ainda estará lá, mas nossos empregos estão em jogo, então não se esqueça de validar tudo. 🙂
+
+Sobre o tema de validações, outra coisa que me chamou a atenção é que o Gemini estava sugerindo um tipo de instância Cloud SQL razoavelmente grande: `db-perf-optimized-N-8`. Vamos tentar outro prompt para melhorar isso, pois isso definitivamente é demais para um protótipo pequeno:
+
+> Torne-o econômico
+
+![alt_text](images/image012.png "Resposta do Gemini sugerindo um balanceador de carga regional e substituindo o Postgres por MySQL")
+
+Hmmm… essa me fez pensar. Entendo o ponto sobre o balanceador de carga regional versus global, mas não estou convencido do motivo pelo qual ele acha que o MySQL é mais econômico do que o PostgreSQL. Eu estava mais preocupado com o tipo de máquina do que com a tecnologia de banco de dados real.
+
+A resposta do Gemini não nos conta toda a história, no entanto. Inspecionando o `diff` de perto, ele nos mostra que na verdade modificou o tipo de máquina (mostrado como o atributo `tier`) e simplesmente esqueceu de nos dizer:
+
+![alt_text](images/image013.png "Diff do Terraform mostrando que o Gemini também alterou o tipo de máquina (tier)")
+
+Não estou totalmente satisfeito com isso, então vou perguntar por quê:
+
+![alt_text](images/image014.png "Perguntando ao Gemini por que ele acha que o MySQL é mais econômico do que o Postgres")
+
+A resposta sugere que o MySQL é mais econômico que o Postgres devido a:
+1. Diferenças de licenciamento
+2. Consumo de recursos
+3. Preços de serviços gerenciados
+
+Infelizmente, não posso concordar com esta resposta. Para o item 1, ambos têm licenças de código aberto, portanto, não são tão diferentes. Talvez o item 2 possa ter alguma verdade, mas eu ainda precisaria de um benchmark adequado. O item 3 está errado porque o Cloud SQL para Postgres e MySQL têm o mesmo modelo de preços no GCP. Mais um ponto para os humanos, vamos reverter a mudança:
+
+> reverta a alteração de postgres para mysql, mas mantenha o tipo de máquina menor.
+
+Inspeção final: estou feliz com o Cloud SQL executando Postgres em um nível de banco de dados menor, mas também descobri que há outra edição notável que ativa o recurso de escalonamento para zero do Cloud Run:
+
+![alt_text](images/image015.png "Diff do Terraform mostrando que o Cloud Run foi configurado com escalonamento para zero (min_instance_count = 0)")
+
+Este faz muito sentido, mas também não foi mencionado no diálogo. Este é outro lembrete para “confiar, mas verificar” o que quer que sua ferramenta de IA esteja lhe dizendo. Não queremos surpresas rodando em produção.
+
+## Recuperando os Arquivos Terraform
+
+Depois de estar satisfeito com o design, você pode clicar no botão “&lt;&gt; Get Code” no canto superior direito da interface do usuário. Isso compactará o código terraform subjacente em um arquivo zip para você baixar para sua máquina local.
+
+Infelizmente, no momento em que este artigo foi escrito, o Application Design Center não oferece suporte a nenhuma integração com sistemas de controle de versão de código como GitHub, GitLab, Google Source, Bitbucket e outros. A única maneira de extrair o código da ferramenta é por meio do download deste arquivo zip.
+
+Para pessoas que usam contas corporativas com uma hierarquia organizacional completa, você pode pegar este design e implantá-lo usando o AppHub, mas se você estiver usando sua conta pessoal, infelizmente este é o limite do que a ferramenta pode fazer por você.
+
+
+## Notas sobre a interface do usuário do App Design Center
+
+O botão “Edit app design” terá comportamentos diferentes dependendo de como seu console da nuvem está configurado. Se você estiver testando este prompt de sua conta pessoal e sua conta pessoal não estiver vinculada a uma organização, ele abrirá uma janela de Pré-visualização onde você poderá ver o design e baixar o código terraform correspondente, mas não terá acesso à interface de usuário completa do App Design Center.
+
+Para usar a interface completa, você precisa fazer parte de uma organização, pois a configuração do App Design Center precisa de um tipo especial de pasta configurada, denominada pasta “habilitada para o app design center”. Não há como adicionar pastas a contas sem uma organização e, dentro de uma organização, esta pasta precisa ser configurada pelo administrador da nuvem.
+
+Infelizmente, isso significa que as contas de usuário que não pertencem a nenhuma organização ficarão efetivamente bloqueadas do conjunto completo de recursos do ADC, pelo menos por enquanto.
+
+Você ainda poderá usar o Gemini para ajudá-lo a prototipar a arquitetura do seu aplicativo, assim como mostrei neste artigo, mas não poderá salvar seu progresso na interface do usuário da nuvem e precisará baixar os arquivos terraform para sua máquina local e implantá-los usando sua própria instalação do terraform.
+
+## Conclusões e próximos passos
+
+Cada novo produto de IA lançado me deixa animado com a ideia de ter aquele momento “Tony Stark” em que você pode projetar seu software apenas usando comandos de voz. Ainda não chegamos lá, mas com o Gemini Cloud Assist estamos progredindo bem, pois agora podemos usar linguagem natural para especificar os componentes de infraestrutura para nós.
+
+Ainda existem algumas arestas ásperas tanto em termos de interface do usuário quanto nas sugestões do Gemini, mas já estou aliviado por não ter que criar manualmente o código terraform para cada novo aplicativo que estou desenvolvendo.
+
+Este é claramente um artigo que deve ter uma data de validade, pois devemos ver essa ferramenta evoluir muito rapidamente nos próximos meses. Para se manter atualizado, você sempre pode verificar a página do produto [Application Design Center](https://cloud.google.com/application-design-center/docs/overview?utm_campaign=CDR_0x72884f69_awareness_b428663487&utm_medium=external&utm_source=blog), mas é claro que farei o meu melhor para escrever sobre novos recursos e melhorias interessantes neste blog também.
+
+Como algumas sugestões, recomendo que você experimente alguns prompts criativos como “torne-o econômico”, “torne-o altamente disponível”, “explique por que x em vez de y”, “substitua x por y”, “explique x para mim como se eu tivesse 5 anos”, e assim por diante.
+
+Quais são seus pensamentos? Você achou esta ferramenta empolgante ou assustadora? Você encontrou algum prompt interessante? Deixe seus comentários abaixo!


### PR DESCRIPTION
This commit adds Portuguese (Brazil) translations for all existing blog posts. The translated files are named `index.pt-br.md` and are located in the same directory as the original `index.md` files.